### PR TITLE
Update port and healthcheck endpoint to work with eQ

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
-docker build -t eu.gcr.io/census-gcr-int/census-maintenance-page:latest .
-docker push eu.gcr.io/census-gcr-int/census-maintenance-page:latest
+docker build -t eu.gcr.io/census-eq-ci/eq-census-maintenance-page:latest .
+docker push eu.gcr.io/census-eq-ci/eq-census-maintenance-page:latest

--- a/nginx/conf.d/default.conf
+++ b/nginx/conf.d/default.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default;
+    listen 5000 default;
     server_name _;
     server_tokens off;
 
@@ -7,7 +7,7 @@ server {
         return 301 https://$host$request_uri;
     }
 
-    location /healthz {
+    location /status {
         return 200;
     }
 


### PR DESCRIPTION
The eQ version needs to run on the same port and have the same healthcheck as eQ because it will be deployed in place of runner.